### PR TITLE
Reduced POS difficulty, version bump, protocol bump.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nMajorityWindow = 1000;
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.posLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.posLimitV2 = uint256S("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.posLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nTargetTimespan = 16 * 60; // 16 mins
         consensus.nTargetSpacingV1 = 60;
         consensus.nTargetSpacing = 64;

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -15,7 +15,7 @@
 
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 13
-#define CLIENT_VERSION_MINOR 0
+#define CLIENT_VERSION_MINOR 1
 #define CLIENT_VERSION_BUILD 1
 
 //! Set to true for release, false for prerelease or test build
@@ -25,7 +25,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2024
+#define COPYRIGHT_YEAR 2025
 
 #endif //HAVE_CONFIG_H
 

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70015;
+static const int PROTOCOL_VERSION = 70016;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -22,7 +22,7 @@ static const int CANONICAL_BLOCK_SIG_VERSION = 60016;
 static const int CANONICAL_BLOCK_SIG_LOW_S_VERSION = 60018;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70015;
+static const int MIN_PEER_PROTO_VERSION = 70016;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Reduced POS diff calculation by reducing posLimitV2 meant for scrypt algo large network. 
Tribus algo and smaller node network with scrypt algo posLimitV2 kept POS difficulty constantly maxed out leading to a very low POS staking reward amount.