### PR TITLE
Qt: add dimi deposit QR for receiving addresses

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -14,7 +14,10 @@
 #include "csvmodelwriter.h"
 #include "editaddressdialog.h"
 #include "guiutil.h"
+#include "optionsmodel.h"
 #include "platformstyle.h"
+#include "receiverequestdialog.h"
+#include "walletmodel.h"
 
 #include <QIcon>
 #include <QMenu>
@@ -26,18 +29,22 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode mode, 
     ui(new Ui::AddressBookPage),
     model(0),
     mode(mode),
-    tab(tab)
+    tab(tab),
+    receiveCfg(0),
+    optionsModel(0)
 {
     ui->setupUi(this);
 
     if (!platformStyle->getImagesOnButtons()) {
         ui->newAddress->setIcon(QIcon());
         ui->copyAddress->setIcon(QIcon());
+        ui->showQr->setIcon(QIcon());
         ui->deleteAddress->setIcon(QIcon());
         ui->exportButton->setIcon(QIcon());
     } else {
         ui->newAddress->setIcon(platformStyle->SingleColorIcon(":/icons/add"));
         ui->copyAddress->setIcon(platformStyle->SingleColorIcon(":/icons/editcopy"));
+        ui->showQr->setIcon(platformStyle->SingleColorIcon(":/icons/receiving_addresses"));
         ui->deleteAddress->setIcon(platformStyle->SingleColorIcon(":/icons/remove"));
         ui->exportButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
     }
@@ -69,10 +76,12 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode mode, 
     case SendingTab:
         ui->labelExplanation->setText(tr("These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins."));
         ui->deleteAddress->setVisible(true);
+        ui->showQr->setVisible(false);
         break;
     case ReceivingTab:
         ui->labelExplanation->setText(tr("These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction."));
         ui->deleteAddress->setVisible(false);
+        ui->showQr->setVisible(mode == ForEditing);
         break;
     }
 
@@ -100,6 +109,9 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode mode, 
     connect(ui->tableView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
 
     connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(accept()));
+
+    ui->showQr->setVisible(tab == ReceivingTab && mode == ForEditing);
+    ui->showQr->setEnabled(false);
 }
 
 AddressBookPage::~AddressBookPage()
@@ -152,9 +164,37 @@ void AddressBookPage::setModel(AddressTableModel *model)
     selectionChanged();
 }
 
+void AddressBookPage::setReceiveDialogContext(const Config *cfg, OptionsModel *optionsModel)
+{
+    receiveCfg = cfg;
+    this->optionsModel = optionsModel;
+}
+
 void AddressBookPage::on_copyAddress_clicked()
 {
     GUIUtil::copyEntryData(ui->tableView, AddressTableModel::Address);
+}
+
+void AddressBookPage::on_showQr_clicked()
+{
+    if (!receiveCfg || !optionsModel || !ui->tableView->selectionModel())
+        return;
+
+    QModelIndexList indexes = ui->tableView->selectionModel()->selectedRows(AddressTableModel::Address);
+    if (indexes.isEmpty())
+        return;
+
+    const QString address = indexes.at(0).data(Qt::EditRole).toString();
+    const QModelIndex labelIndex = indexes.at(0).sibling(indexes.at(0).row(), AddressTableModel::Label);
+    const QString label = labelIndex.data(Qt::EditRole).toString();
+
+    SendCoinsRecipient info(address, label, 0, "");
+    ReceiveRequestDialog *dialog = new ReceiveRequestDialog(receiveCfg, this);
+    dialog->setQrUriMode(ReceiveRequestDialog::DimiDepositUri);
+    dialog->setModel(optionsModel);
+    dialog->setInfo(info);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
 }
 
 void AddressBookPage::onCopyLabelAction()
@@ -237,11 +277,14 @@ void AddressBookPage::selectionChanged()
             break;
         }
         ui->copyAddress->setEnabled(true);
+        if (tab == ReceivingTab && mode == ForEditing)
+            ui->showQr->setEnabled(true);
     }
     else
     {
         ui->deleteAddress->setEnabled(false);
         ui->copyAddress->setEnabled(false);
+        ui->showQr->setEnabled(false);
     }
 }
 

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -8,6 +8,7 @@
 #include <QDialog>
 
 class AddressTableModel;
+class Config;
 class OptionsModel;
 class PlatformStyle;
 
@@ -44,6 +45,7 @@ public:
     ~AddressBookPage();
 
     void setModel(AddressTableModel *model);
+    void setReceiveDialogContext(const Config *cfg, OptionsModel *optionsModel);
     const QString &getReturnValue() const { return returnValue; }
 
 public Q_SLOTS:
@@ -59,6 +61,8 @@ private:
     QMenu *contextMenu;
     QAction *deleteAction; // to be able to explicitly disable it
     QString newAddressToSelect;
+    const Config *receiveCfg;
+    OptionsModel *optionsModel;
 
 private Q_SLOTS:
     /** Delete currently selected address entry */
@@ -67,6 +71,8 @@ private Q_SLOTS:
     void on_newAddress_clicked();
     /** Copy address of currently selected address entry to clipboard */
     void on_copyAddress_clicked();
+    /** Show QR code for the selected receiving address */
+    void on_showQr_clicked();
     /** Copy label of currently selected address entry to clipboard (no button) */
     void onCopyLabelAction();
     /** Edit currently selected address entry (no button) */

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -86,6 +86,23 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="showQr">
+       <property name="toolTip">
+        <string>Show a QR code for the selected address (dimi: URI for mobile)</string>
+       </property>
+       <property name="text">
+        <string>Show &amp;QR</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/receiving_addresses</normaloff>:/icons/receiving_addresses</iconset>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="deleteAddress">
        <property name="toolTip">
         <string>Delete the currently selected address from the list</string>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -306,6 +306,11 @@ QString formatBitcoinURI(const Config &cfg, const SendCoinsRecipient &info)
     return ret;
 }
 
+QString formatDimiDepositURI(const QString &address)
+{
+    return QStringLiteral("dimi:%1").arg(address.trimmed());
+}
+
 bool isDust(const QString& address, const CAmount& amount)
 {
     CTxDestination dest = DecodeDestination(address.toStdString());

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -56,6 +56,8 @@ namespace GUIUtil
     bool parseBitcoinURI(const QString &scheme, const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(const QString &scheme, QString uri, SendCoinsRecipient *out);
     QString formatBitcoinURI(const Config &cfg, const SendCoinsRecipient &info);
+    /** dimi: URI for mobile deposit QR codes (miniapp scanner). */
+    QString formatDimiDepositURI(const QString &address);
 
     // Returns true if given address+amount meets "dust" definition
     bool isDust(const QString& address, const CAmount& amount);

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -97,7 +97,8 @@ ReceiveRequestDialog::ReceiveRequestDialog(const Config *cfg, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ReceiveRequestDialog),
     model(0),
-    cfg(cfg)
+    cfg(cfg),
+    qrUriMode(PaymentRequestUri)
 {
     ui->setupUi(this);
 
@@ -148,6 +149,12 @@ void ReceiveRequestDialog::setInfo(const SendCoinsRecipient &_info)
     update();
 }
 
+void ReceiveRequestDialog::setQrUriMode(QrUriMode mode)
+{
+    qrUriMode = mode;
+    update();
+}
+
 void ReceiveRequestDialog::update()
 {
     if(!model)
@@ -155,36 +162,55 @@ void ReceiveRequestDialog::update()
     QString target = info.label;
     if(target.isEmpty())
         target = info.address;
-    setWindowTitle(tr("Request payment to %1").arg(target));
 
-    QString uri = GUIUtil::formatBitcoinURI(*cfg, info);
+    const QString desktopUri = GUIUtil::formatBitcoinURI(*cfg, info);
+    const QString qrUri = qrUriMode == DimiDepositUri
+        ? GUIUtil::formatDimiDepositURI(info.address)
+        : desktopUri;
+
+    if (qrUriMode == DimiDepositUri) {
+        setWindowTitle(tr("Show QR for %1").arg(target));
+        ui->btnCopyURI->setText(tr("Copy &dimi URI"));
+    } else {
+        setWindowTitle(tr("Request payment to %1").arg(target));
+        ui->btnCopyURI->setText(tr("Copy &URI"));
+    }
+
     ui->btnSaveAs->setEnabled(false);
     QString html;
     html += "<html><font face='verdana, arial, helvetica, sans-serif'>";
     html += "<b>"+tr("Payment information")+"</b><br>";
-    html += "<b>"+tr("URI")+"</b>: ";
-    html += "<a href=\""+uri+"\">" + GUIUtil::HtmlEscape(uri) + "</a><br>";
-    html += "<b>"+tr("Address")+"</b>: " + GUIUtil::HtmlEscape(info.address) + "<br>";
-    if(info.amount)
-        html += "<b>"+tr("Amount")+"</b>: " + BitcoinUnits::formatHtmlWithUnit(model->getDisplayUnit(), info.amount) + "<br>";
-    if(!info.label.isEmpty())
-        html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
-    if(!info.message.isEmpty())
-        html += "<b>"+tr("Message")+"</b>: " + GUIUtil::HtmlEscape(info.message) + "<br>";
+    if (qrUriMode == DimiDepositUri) {
+        if(!info.label.isEmpty())
+            html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
+        html += "<b>"+tr("Address")+"</b>: <span style='font-family:monospace; font-size:11px;'>" + GUIUtil::HtmlEscape(info.address) + "</span>";
+    } else {
+        html += "<b>"+tr("URI")+"</b>: ";
+        html += "<a href=\""+desktopUri+"\">" + GUIUtil::HtmlEscape(desktopUri) + "</a><br>";
+        html += "<b>"+tr("Address")+"</b>: " + GUIUtil::HtmlEscape(info.address) + "<br>";
+        if(info.amount)
+            html += "<b>"+tr("Amount")+"</b>: " + BitcoinUnits::formatHtmlWithUnit(model->getDisplayUnit(), info.amount) + "<br>";
+        if(!info.label.isEmpty())
+            html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
+        if(!info.message.isEmpty())
+            html += "<b>"+tr("Message")+"</b>: " + GUIUtil::HtmlEscape(info.message) + "<br>";
+    }
+    html += "</font></html>";
     ui->outUri->setText(html);
 
 #ifdef USE_QRCODE
-    int fontSize = cfg->UseCashAddrEncoding() ? 10 : 12;
+    const bool showAddressUnderQr = (qrUriMode != DimiDepositUri);
+    const int qrCanvasHeight = showAddressUnderQr ? QR_IMAGE_SIZE + 20 : QR_IMAGE_SIZE;
 
     ui->lblQRCode->setText("");
-    if(!uri.isEmpty())
+    if(!qrUri.isEmpty())
     {
         // limit URI length
-        if (uri.length() > MAX_URI_LENGTH)
+        if (qrUri.length() > MAX_URI_LENGTH)
         {
             ui->lblQRCode->setText(tr("Resulting URI too long, try to reduce the text for label / message."));
         } else {
-            QRcode *code = QRcode_encodeString(uri.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            QRcode *code = QRcode_encodeString(qrUri.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
             if (!code)
             {
                 ui->lblQRCode->setText(tr("Error encoding URI into QR Code."));
@@ -203,16 +229,19 @@ void ReceiveRequestDialog::update()
             }
             QRcode_free(code);
 
-            QImage qrAddrImage = QImage(QR_IMAGE_SIZE, QR_IMAGE_SIZE+20, QImage::Format_RGB32);
+            QImage qrAddrImage = QImage(QR_IMAGE_SIZE, qrCanvasHeight, QImage::Format_RGB32);
             qrAddrImage.fill(0xffffff);
             QPainter painter(&qrAddrImage);
             painter.drawImage(0, 0, qrImage.scaled(QR_IMAGE_SIZE, QR_IMAGE_SIZE));
-            QFont font = GUIUtil::fixedPitchFont();
-            font.setPixelSize(fontSize);
-            painter.setFont(font);
-            QRect paddedRect = qrAddrImage.rect();
-            paddedRect.setHeight(QR_IMAGE_SIZE+12);
-            painter.drawText(paddedRect, Qt::AlignBottom|Qt::AlignCenter, info.address);
+            if (showAddressUnderQr) {
+                int fontSize = cfg->UseCashAddrEncoding() ? 10 : 12;
+                QFont font = GUIUtil::fixedPitchFont();
+                font.setPixelSize(fontSize);
+                painter.setFont(font);
+                QRect paddedRect = qrAddrImage.rect();
+                paddedRect.setHeight(QR_IMAGE_SIZE+12);
+                painter.drawText(paddedRect, Qt::AlignBottom|Qt::AlignCenter, info.address);
+            }
             painter.end();
 
             ui->lblQRCode->setPixmap(QPixmap::fromImage(qrAddrImage));
@@ -224,7 +253,11 @@ void ReceiveRequestDialog::update()
 
 void ReceiveRequestDialog::on_btnCopyURI_clicked()
 {
-    GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(*cfg, info));
+    if (qrUriMode == DimiDepositUri) {
+        GUIUtil::setClipboard(GUIUtil::formatDimiDepositURI(info.address));
+    } else {
+        GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(*cfg, info));
+    }
 }
 
 void ReceiveRequestDialog::on_btnCopyAddress_clicked()

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -58,6 +58,12 @@ public:
     void setModel(OptionsModel *model);
     void setInfo(const SendCoinsRecipient &info);
 
+    enum QrUriMode {
+        PaymentRequestUri,
+        DimiDepositUri,
+    };
+    void setQrUriMode(QrUriMode mode);
+
 private Q_SLOTS:
     void on_btnCopyURI_clicked();
     void on_btnCopyAddress_clicked();
@@ -69,6 +75,7 @@ private:
     OptionsModel *model;
     SendCoinsRecipient info;
     const Config *cfg;
+    QrUriMode qrUriMode;
 };
 
 // exported for unittesting

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -33,7 +33,8 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, const Config *cfg, Q
     QStackedWidget(parent),
     clientModel(0),
     walletModel(0),
-    platformStyle(_platformStyle)
+    platformStyle(_platformStyle),
+    cfg(cfg)
 {
     // Create tabs
     overviewPage = new OverviewPage(platformStyle);
@@ -123,6 +124,7 @@ void WalletView::setWalletModel(WalletModel *walletModel)
     receiveCoinsPage->setModel(walletModel);
     sendCoinsPage->setModel(walletModel);
     usedReceivingAddressesPage->setModel(walletModel->getAddressTableModel());
+    usedReceivingAddressesPage->setReceiveDialogContext(cfg, walletModel ? walletModel->getOptionsModel() : nullptr);
     usedSendingAddressesPage->setModel(walletModel->getAddressTableModel());
 
     if (walletModel)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -70,6 +70,7 @@ private:
 
     QProgressDialog *progressDialog;
     const PlatformStyle *platformStyle;
+    const Config *cfg;
 
 public Q_SLOTS:
     /** Switch to overview (home) page */


### PR DESCRIPTION
- Show QR button in the receiving addresses list  
- QR encodes `dimi:ADDRESS`  
- Copy URI; no address shown below the QR in deposit mode  
- Build with `USE_QRCODE=1`