### PR TITLE
wallet: fix stale coinstake accounting after reorgs

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1309,7 +1309,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
             walletdb.WriteTx(wtx);
             NotifyTransactionChanged(this, wtx.GetHash(), CT_UPDATED);
             // Iterate over all its outputs, and mark transactions in the wallet that spend them abandoned too
-            TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(hashTx, 0));
+            TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(now, 0));
             while (iter != mapTxSpends.end() && iter->first.hash == now) {
                 if (!done.count(iter->second)) {
                     todo.insert(iter->second);
@@ -1397,6 +1397,12 @@ void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex,
         if (tx.IsCoinStake()) {
             if (IsFromMe(tx)) {
                 DisableTransaction(tx);
+                BOOST_FOREACH(const CTxIn& txin, tx.vin)
+                {
+                    map<uint256, CWalletTx>::iterator mi = mapWallet.find(txin.prevout.hash);
+                    if (mi != mapWallet.end())
+                        mi->second.MarkDirty();
+                }
                 return;
             }
         }
@@ -2187,7 +2193,7 @@ CAmount CWallet::GetStake() const
     for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
         const CWalletTx* pcoin = &(*it).second;
-        if (pcoin->IsCoinStake() && pcoin->GetBlocksToMaturity() > 0 && pcoin->GetDepthInMainChain() > 0)
+        if (pcoin->IsCoinStake() && pcoin->IsTrusted() && pcoin->GetBlocksToMaturity() > 0 && pcoin->GetDepthInMainChain() > 0)
             nTotal += CWallet::GetCredit(*pcoin, ISMINE_SPENDABLE);
     }
     return nTotal;
@@ -3394,18 +3400,39 @@ void CWallet::DisableTransaction(const CTransaction &tx)
 
     LOCK(cs_wallet);
     uint256 hash = tx.GetHash();
+    map<uint256, CWalletTx>::iterator mi = mapWallet.find(hash);
+    if (mi == mapWallet.end())
+        return;
+
     if(AbandonTransaction(hash))
     {
         RemoveFromSpends(hash);
-        set<CWalletTx*> setCoins;
         BOOST_FOREACH(const CTxIn& txin, tx.vin)
         {
-            CWalletTx &coin = mapWallet[txin.prevout.hash];
+            map<uint256, CWalletTx>::iterator it = mapWallet.find(txin.prevout.hash);
+            if (it == mapWallet.end())
+                continue;
+            CWalletTx &coin = it->second;
             coin.BindWallet(this);
+            coin.MarkDirty();
             NotifyTransactionChanged(this, coin.GetHash(), CT_UPDATED);
         }
-        CWalletTx& wtx = mapWallet[hash];
+
+        TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(hash, 0));
+        while (iter != mapTxSpends.end() && iter->first.hash == hash) {
+            map<uint256, CWalletTx>::iterator it = mapWallet.find(iter->second);
+            if (it != mapWallet.end()) {
+                CWalletTx &coin = it->second;
+                coin.BindWallet(this);
+                coin.MarkDirty();
+                NotifyTransactionChanged(this, coin.GetHash(), CT_UPDATED);
+            }
+            iter++;
+        }
+
+        CWalletTx& wtx = mi->second;
         wtx.BindWallet(this);
+        wtx.MarkDirty();
         NotifyTransactionChanged(this, hash, CT_DELETED);
     }
 }


### PR DESCRIPTION
Cherry-pick of the wallet commit from #5 by @dtd-tosh, unchanged (`74d6217`, authorship preserved). Split out so the wallet fixes can land on their own; see #5 for why the second commit in that PR was not carried over.

Wallet-local only — no consensus or block validation impact.

## What it fixes

**`AbandonTransaction` recursion (`wallet.cpp:1312`)** — `mapTxSpends.lower_bound(COutPoint(hashTx, 0))` seeds the iterator from the *root* txid while the loop condition tests `iter->first.hash == now`. For every descendant past the first level the iterator starts at the wrong key and the body never runs, so abandonment silently stops one level deep. The fix (`now` instead of `hashTx`) matches upstream Bitcoin Core.

**`DisableTransaction` phantom entries and assert crashes** — `mapWallet[...]` is `std::map::operator[]`, which default-inserts when the key is absent, polluting the wallet with empty `CWalletTx` entries and firing `NotifyTransactionChanged` on them. Beyond that, the added `mapWallet.find()` guard prevents two assertion crashes that the PR description does not claim:

- `AbandonTransaction`'s `assert(mapWallet.count(hashTx))` (`wallet.cpp:1285`)
- `RemoveFromSpends`'s `assert(mapWallet.count(wtxid))` (`wallet.cpp:582`)

`DisableTransaction` is reachable from `SyncTransaction` whenever `IsFromMe(tx)`, which only tests that the *inputs* are ours — so the coinstake itself need not be in `mapWallet`.

**`MarkDirty()` on disconnected inputs and spenders** — cache invalidation, and the actual mechanism behind the stale balance.

## Review notes

- `mapWallet` is `std::map` (`wallet.h:659`), so the `mi` iterator held across the `AbandonTransaction(hash)` call in the rewritten `DisableTransaction` stays valid. With `unordered_map` this would have been a use-after-invalidate.
- The `GetStake()` change adding `IsTrusted()` is effectively a no-op: the filter already requires `GetDepthInMainChain() > 0`, and `IsTrusted()` returns `true` immediately at `nDepth >= 1` (`wallet.cpp:2045`), so it reduces to `CheckFinalTx()`. Harmless; kept for fidelity with the original commit.

## Testing

Original author reported successful Linux daemon and Windows Qt builds, and no recurrence of the stale balance under observation. Reviewed here by reading; the stale-balance bug has not been reproduced against a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)