### PR TITLE
Keep MIN_PEER_PROTO_VERSION at 70016 for 13.2.0

### DIFF
--- a/doc/pos-limit-reduction.md
+++ b/doc/pos-limit-reduction.md
@@ -93,6 +93,26 @@ first block using the reduced one, so a synced node can find it over RPC without
 the diagnostic build — scan `getblockheader` in the region around 2025-07-13 for
 the transition from `bits: "1b00ffff"` to `bits: "1e0fffff"`.
 
+## Network compatibility
+
+This is **not** a fork of the rules applied to new blocks, and no coordinated
+upgrade is required.
+
+Pre-13.2.0 code applies the reduced limit at every height. 13.2.0 applies it at
+every height at or above `nPosLimitV2ReducedHeight` (190927). The chain passed
+that height in July 2025, so for every block mined from then on the two versions
+compute **identical** difficulty and interoperate normally — staking, relay and
+mining are unaffected.
+
+The versions differ only when re-validating history *below* 190927, which
+happens during a reindex or a sync from scratch. A 13.1.x node keeps following
+the chain it already has; it just cannot rebuild its index.
+
+`MIN_PEER_PROTO_VERSION` is therefore deliberately left at 70016 while
+`PROTOCOL_VERSION` advertises 70017. Raising the minimum would disconnect peers
+that are fully compatible, partitioning the network for no consensus benefit.
+Raise it only when new blocks are actually validated differently.
+
 ## Other networks
 
 Testnet and regtest never received the reduction; they set

--- a/src/version.h
+++ b/src/version.h
@@ -22,7 +22,13 @@ static const int CANONICAL_BLOCK_SIG_VERSION = 60016;
 static const int CANONICAL_BLOCK_SIG_LOW_S_VERSION = 60018;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70017;
+//! Deliberately left at 70016 for the 70017 (13.2.0) release. The PoS limit
+//! change in 13.2.0 only alters validation of blocks below height 190927, and
+//! the chain is far past that, so 13.1.x and 13.2.0 nodes compute identical
+//! difficulty for every new block and interoperate normally. 13.1.x simply
+//! cannot reindex or sync from scratch. Do not raise this without an actual
+//! divergence in the rules applied to new blocks.
+static const int MIN_PEER_PROTO_VERSION = 70016;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Follow-up to #7. The `MIN_PEER_PROTO_VERSION` bump to 70017 in that PR was unnecessary and should be reverted before 13.2.0 ships.

## Why

I recommended the bump in #7 on the assumption that 13.1.x and 13.2.0 would disagree about new blocks. They don't.

- Pre-13.2.0 code applies the reduced PoS limit at **every** height.
- 13.2.0 applies it at every height **>= 190927**.
- The chain passed 190927 on 2025-07-14 and is now at ~1105631.

So for every block mined from here on, both versions compute **identical** difficulty. They diverge only when re-validating history below 190927 — during a reindex or a sync from scratch. A 13.1.x node keeps following the chain it already has and relays and stakes normally; it simply cannot rebuild its index until it upgrades.

Raising the minimum would disconnect fully compatible peers (`main.cpp:5268`, the sole use site) and partition the network for no consensus benefit.

## What changes

- `MIN_PEER_PROTO_VERSION` 70017 -> 70016
- `PROTOCOL_VERSION` stays 70017, so 13.2.0 is still identifiable on the network
- Reasoning documented in `version.h` and `doc/pos-limit-reduction.md` so the minimum isn't raised again without an actual divergence

## Effect

No upgrade deadline and no announced flag day. Users and services upgrade whenever they like; the only incentive is that reindex and fresh sync require 13.2.0.

This supersedes the idea of an auto-flip at a future height — with no divergence there is nothing to flip to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)