### PR TITLE
doc: clarify the coinstake txid note in 13.2.0 release notes

### DIFF
--- a/doc/release-notes/release-notes-13.2.0.md
+++ b/doc/release-notes/release-notes-13.2.0.md
@@ -128,11 +128,23 @@ Known issues
 ============
 
 * **Coinstake transaction IDs are not guaranteed unique.** Transaction `nTime` is
-  not serialised for version 2 transactions and therefore does not contribute to
-  the transaction hash, so two staking attempts spending the same input with
-  identical outputs produce the same txid. Any fix must vary data that is
-  actually serialised. If you encounter duplicate-transaction or overwrite
-  errors, please open an issue with the exact log text.
+  not serialised for version 2 transactions, so it does not contribute to the
+  transaction hash. Two staking attempts spending the same inputs with the same
+  outputs therefore produce the same txid.
+
+  This is a quirk rather than an active fault. Its practical consequence was the
+  wallet accounting problem fixed in this release: the wallet indexes
+  transactions by txid, so an orphaned coinstake and a later re-mined one shared
+  a single entry. At the chain level the duplicate-transaction rule (BIP30) is
+  enforced on every block and cannot be triggered by this, because a coinstake
+  spends its own input — a duplicate can only be mined on a chain where the
+  original is absent, and there its outputs are not in the UTXO set. A full
+  revalidation of the chain to height 1100000 recorded no occurrences.
+
+  Making coinstake txids unique would mean changing the transactions the wallet
+  produces, which is not justified by any observed failure. If you do encounter
+  duplicate-transaction or overwrite errors, please open an issue with the exact
+  log text.
 
 * **The unit test suite does not build.** It was never adapted from the upstream
   Blackcoin More codebase. This does not affect the released binaries, which do


### PR DESCRIPTION
Follow-up to #10. The known-issues entry read as an outstanding defect; investigation shows it is a quirk whose only practical consequence is already fixed by #8.

- `nTime` is not serialised at `nVersion >= 2`, and `GetProofOfStakeSubsidy()` is a fixed constant per halving interval, so identical inputs and fees do yield identical txids.
- BIP30 is enforced on every block (`BIP34Hash` is `uint256()`, so the guard at `main.cpp:2546` never disables it), but it cannot fire for a coinstake: the transaction spends its own input, so a duplicate can only be mined on a chain where the original is absent, where its outputs are not in the UTXO set.
- Wallet-level impact is the stale accounting fixed in #8. `AddToWallet` (`wallet.cpp:1181`) clears the abandoned sentinel when the txid reappears in a block, so recovery works once the caches are invalidated.
- Empirical: a full reindex to height 1100000 with BIP30 enforced logged zero duplicate/overwrite events.

No code change — changing block production is not justified by any observed failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)