### PR TITLE
Fix spurious large-work fork warning on the hybrid chain

### DIFF
--- a/doc/release-notes/release-notes-13.2.0.md
+++ b/doc/release-notes/release-notes-13.2.0.md
@@ -102,6 +102,29 @@ inserted into the wallet.
 
 Thanks to **dtd-tosh** for finding and fixing this.
 
+Fixed: spurious "the network does not appear to fully agree" warning
+--------------------------------------------------------------------
+
+Wallets have long shown this popup during normal operation:
+
+    Warning: The network does not appear to fully agree!
+    Some miners appear to be experiencing issues.
+
+It was a false alarm. The check behind it is inherited from Bitcoin, where every
+block carries roughly the same amount of work, so "a fork worth 7 blocks" can be
+estimated as one block's work multiplied by seven. On a hybrid proof-of-work /
+proof-of-stake chain that assumption does not hold — the two block types run at
+independent difficulties, and a stake block can be worth well over a thousand
+work blocks.
+
+The result was that a single competing stake block, which is ordinary stake
+competition and entirely harmless, could exceed the threshold by a factor of
+several hundred and be reported as a large-work fork.
+
+The check now measures a real span of the chain, which contains both block types
+in their natural proportion, and additionally requires a fork to actually be
+seven blocks long. Genuine large forks are still reported.
+
 Updated checkpoints and minimum chain work
 -------------------------------------------
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1888,6 +1888,34 @@ static void AlertNotify(const std::string& strMessage)
     boost::thread t(runCommand, strCmd); // thread runs free
 }
 
+/**
+ * Work contained in the nBlocks main-chain blocks ending at pindex.
+ *
+ * The fork warnings below are inherited from Bitcoin, where every block carries
+ * roughly the same work and "n blocks of work" can be approximated by the proof
+ * of a single block times n. That does not hold on a hybrid proof-of-work /
+ * proof-of-stake chain: the two block types run at completely independent
+ * difficulties, and a single stake block can be worth a thousand work blocks or
+ * more. Using one block as the yardstick therefore made the thresholds wildly
+ * sensitive whenever the reference block happened to be the cheaper type, and a
+ * single competing stake block was enough to be reported as a large-work fork.
+ *
+ * Measuring a real span of the chain instead is self-normalising, since the span
+ * contains both block types in whatever proportion the chain is actually
+ * producing them.
+ */
+static arith_uint256 GetRecentChainWork(const CBlockIndex* pindex, int nBlocks)
+{
+    if (pindex == NULL)
+        return arith_uint256(0);
+
+    const CBlockIndex* pstart = pindex->GetAncestor(std::max(0, pindex->nHeight - nBlocks));
+    if (pstart == NULL || pstart->nChainWork > pindex->nChainWork)
+        return GetBlockProof(*pindex) * nBlocks; // degenerate; fall back to the old estimate
+
+    return pindex->nChainWork - pstart->nChainWork;
+}
+
 void CheckForkWarningConditions()
 {
     AssertLockHeld(cs_main);
@@ -1901,7 +1929,7 @@ void CheckForkWarningConditions()
     if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 72)
         pindexBestForkTip = NULL;
 
-    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (GetBlockProof(*chainActive.Tip()) * 6)))
+    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + GetRecentChainWork(chainActive.Tip(), 6)))
     {
         if (!fLargeWorkForkFound && pindexBestForkBase)
         {
@@ -1951,8 +1979,15 @@ void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     // or a chain that is entirely longer than ours and invalid (note that this should be detected by both)
     // We define it this way because it allows us to only store the highest fork tip (+ base) which meets
     // the 7-block condition and from this always have the most-likely-to-cause-warning fork
+    //
+    // The fork must be at least 7 blocks long as well as carry more work than the 7
+    // main-chain blocks it forked from. On a hybrid chain the work test alone is not
+    // enough: a lone competing stake block forking off a work block clears any
+    // work-only threshold by orders of magnitude, and that is ordinary stake
+    // competition rather than anything worth warning about.
     if (pfork && (!pindexBestForkTip || (pindexBestForkTip && pindexNewForkTip->nHeight > pindexBestForkTip->nHeight)) &&
-            pindexNewForkTip->nChainWork - pfork->nChainWork > (GetBlockProof(*pfork) * 7) &&
+            pindexNewForkTip->nHeight - pfork->nHeight >= 7 &&
+            pindexNewForkTip->nChainWork - pfork->nChainWork > GetRecentChainWork(pfork, 7) &&
             chainActive.Height() - pindexNewForkTip->nHeight < 72)
     {
         pindexBestForkTip = pindexNewForkTip;


### PR DESCRIPTION
Fixes the long-standing popup:

> Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.

## Cause

`CheckForkWarningConditionsOnNewFork` judges a fork large when its excess work exceeds `GetBlockProof(*pfork) * 7` — Bitcoin's approximation of "7 blocks of work", valid because Bitcoin blocks all carry roughly equal work.

This chain is hybrid, and the two block types run at independent difficulties:

| block | bits | work |
|---|---|---|
| PoW (1100000) | `1c0d957f` | 8.09e10 |
| PoS (190927) | `1b021ffd` | 1.33e14 |

A stake block is worth **1636x** a work block. When the fork base is a work block the threshold is `5.7e11`, while one stake block contributes `1.3e14` — over by 234x. The condition is met by **0.004 of a single stake block**.

The chain is ~50% proof-of-stake with constant single-block stake competition, so roughly half of all fork bases are work blocks. Any rejected competing stake block — duplicate stake, stake already used, timestamp rules, all routine — was classified as a large-work fork.

## Fix

- Measure the work of a real span of the main chain (`GetRecentChainWork`) rather than one block times n. Self-normalising: the span contains both block types in their natural proportion.
- Additionally require the fork to be at least 7 blocks long — the condition the existing comment already describes, but which the work test alone never enforced.
- Same treatment for the `pindexBestInvalid` clause, which had the identical flaw with `* 6`.

Genuine large forks are still reported.

## Scope

Local warning heuristic only. No consensus, validation, relay or network behaviour changes. Release notes updated; 13.2.0 has not shipped yet, so this folds into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)