### PR TITLE
wallet: restore spend tracking when a transaction is confirmed again

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -541,9 +541,20 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
 
 void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 {
+    pair<TxSpends::iterator, TxSpends::iterator> range;
+
+    // Idempotent. DisableTransaction() drops a coinstake's spends when its block
+    // is disconnected, and the same transaction is added again when a block
+    // containing it reconnects, so this can legitimately be called more than once
+    // for the same pair. mapTxSpends is a multimap and would otherwise accumulate
+    // duplicates.
+    range = mapTxSpends.equal_range(outpoint);
+    for (TxSpends::iterator it = range.first; it != range.second; ++it)
+        if (it->second == wtxid)
+            return;
+
     mapTxSpends.insert(make_pair(outpoint, wtxid));
 
-    pair<TxSpends::iterator, TxSpends::iterator> range;
     range = mapTxSpends.equal_range(outpoint);
     SyncMetaData(range);
 }
@@ -1177,6 +1188,15 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
         bool fUpdated = false;
         if (!fInsertedNew)
         {
+            // Restore this transaction's spends. They are only registered above
+            // when the entry is first inserted, but DisableTransaction() removes
+            // them when a coinstake is disconnected. A transaction that is later
+            // confirmed again takes this merge path, and without re-registering
+            // them its inputs would stay marked unspent: the wallet would then
+            // count the staked coins both as available balance and as stake,
+            // inflating the total until a restart rebuilt mapTxSpends from disk.
+            AddToSpends(hash);
+
             // Merge
             if (!wtxIn.hashUnset() && wtxIn.hashBlock != wtx.hashBlock)
             {


### PR DESCRIPTION
Fixes the inflated total balance during staking, reported as 3386 displayed vs 3246 after restart — a 140 discrepancy over 24h on a wallet whose stake rewards are 0.00125 and 0.00000125 per stake. That magnitude rules out reward accrual: it is **staked principal counted twice**.

## Cause

`AddToSpends(hash)` runs at runtime only inside the `fInsertedNew` branch of `AddToWallet`. `DisableTransaction()` calls `RemoveFromSpends(hash)` when a coinstake's block is disconnected. So:

1. Coinstake mined → inserted → `AddToSpends` → inputs marked spent. Leaves `GetBalance()`, enters `GetStake()`. Correct.
2. Block orphaned → `RemoveFromSpends` → inputs unmarked → back in `GetBalance()`. Still correct.
3. Same coinstake confirmed again → `mapWallet.insert` finds the txid → `fInsertedNew = false` → **merge path, `AddToSpends` never runs**.
4. Depth > 0 again → counted in `GetStake()`. Inputs have no `mapTxSpends` entry → `IsSpent()` false → **also counted in `GetBalance()`**.

Total inflates by the staked principal, permanently for the session. Restart appears to fix it because the load path (`wallet.cpp:1117`) calls `AddToSpends` unconditionally.

Note this needs no txid collision — a plain reorg away from and back to a chain containing the coinstake is enough.

## Fix

- Register spends on the merge path too.
- Make `AddToSpends(const COutPoint&, const uint256&)` idempotent, since it can now legitimately be called twice for the same pair and `mapTxSpends` is a multimap that would otherwise accumulate duplicates.

## Relationship to #8

Different bug. #8 fixed credit-cache invalidation and the abandonment recursion, and those were working correctly here. This is the spend index losing entries, which no amount of cache invalidation recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)