### PR TITLE
Fix chainstate cache poisoning that wedges a mining node on reorg

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -101,7 +101,14 @@ public:
         vout = tx.vout;
         nHeight = nHeightIn;
         nVersion = tx.nVersion;
-        nTime = tx.nTime;
+        // Only version 1 transactions carry nTime through serialization, both
+        // here (see Serialize/Unserialize below) and in CTransaction itself.
+        // A version 2 transaction read back from disk or from the network
+        // always has nTime == 0, but one constructed in memory does not:
+        // CMutableTransaction defaults nTime to GetAdjustedTime(). Copying it
+        // unconditionally would make a cache entry that no reload can
+        // reproduce, and operator== compares nTime.
+        nTime = tx.nVersion < 2 ? tx.nTime : 0;
         ClearUnspendable();
     }
 


### PR DESCRIPTION
## Symptom

A pool daemon gets stuck retrying the same block forever and keeps mining on a stale tip:

```
ERROR: DisconnectBlock(): added transaction mismatch? database corrupted
ERROR: DisconnectTip(): DisconnectBlock 0000000007352c62... failed
ERROR: ProcessNewBlock: ActivateBestChain failed
```

Restarting the daemon clears it immediately; the blocks it had been stuck on then show up as orphans.

## Cause

`CTransaction::nTime` is serialized only for version 1 transactions — for version 2 the deserializer forces it to `0` (`primitives/transaction.h`, `SerializeTransaction`). `CCoins` mirrors that rule in its own `Serialize`/`Unserialize`, but `CCoins::FromTx` copied `tx.nTime` **unconditionally**, and `CCoins::operator==` compares it.

That is harmless for a block received from a peer or read back from disk, because there `nTime` is already `0`. It is not harmless for a block this node built itself:

* `CMutableTransaction()` defaults `nTime` to `GetAdjustedTime()` (`primitives/transaction.cpp:65`), so a locally created coinbase (`miner.cpp:149`), coinstake or wallet transaction carries a **nonzero** `nTime` in memory.
* `ConnectTip` connects the in-memory `pblock` directly instead of re-reading it from disk (`main.cpp:3037`), so `ConnectBlock` writes cache entries holding a value no reload can reproduce.
* `DisconnectTip` **always** reads the block from disk (`main.cpp:2975`), where `nTime` is `0`. `CCoins outsBlock(tx, pindex->nHeight)` therefore has `nTime == 0`, the comparison against the cached entry fails, and `DisconnectBlock` returns false.

Nothing recovers from that state. The flush that would drop the poisoned entry only runs after a *successful* connect or disconnect, so the node retries indefinitely until it is restarted and the chainstate is reloaded from LevelDB with `nTime == 0`.

This is why it only bites nodes that mine or stake their own blocks, and why a restart is a complete cure.

## Fix

Populate `nTime` in `FromTx` under the same version rule the serializer uses, so a cache entry always matches what a reload produces. `FromTx` is the single choke point — `UpdateCoins` (`main.cpp:2082`) and the `CCoins(tx, height)` constructor both go through it, and the undo record at `main.cpp:2077` inherits the corrected value.

## Note on scope

Not related to #12 or #13 — this is long-standing and independent of both. It is, however, the same underlying quirk as the coinstake-txid note in the 13.2.0 release notes: `nTime` not being covered by version 2 serialization.

It also removes a latent consensus divergence. `CheckInputs` rejects a spend when `coins->nTime` is later than the spending transaction (`main.cpp:2137`); a mining node was evaluating that rule against a value its peers did not have.

## Testing

Not compile-verified locally (boost unavailable in this environment). Change is one expression in a header.

To verify: run the pool daemon on a build with this patch and confirm that a self-mined block losing a reorg race is disconnected cleanly instead of wedging `ActivateBestChain`.